### PR TITLE
Add multicluster support

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -8,14 +8,29 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func NewClient() (*kubernetes.Clientset, error) {
+func NewClient(context string) (*kubernetes.Clientset, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
 
 	kubeconfig := filepath.Join(homeDir, ".kube", "config")
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+	// Create a config loading rule that prefers the provided context
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfig
+
+	// Create a config overrides struct and set the context if provided
+	overrides := &clientcmd.ConfigOverrides{}
+	if context != "" {
+		overrides.CurrentContext = context
+	}
+
+	// Create a client config using the loading rules and overrides
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+
+	// Get the rest config
+	config, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit introduces multicluster support, which allows to specify separate K8s contexts for the iperf3 client and server.

An example usage is:
```
k8s-iperf run --k8s-server-context kind-1 --k8s-client-context kind-2 --k8s-multicluster true --k8s-service-annotation "service.cilium.io/global: true"
```

This is using Cilium Cluster Mesh to test cross cluster throughput.